### PR TITLE
chore(ci): add Kanar workflow #PLTM-233

### DIFF
--- a/.github/workflows/kanar.yml
+++ b/.github/workflows/kanar.yml
@@ -1,0 +1,21 @@
+name: Kanar
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+jobs:
+  kanar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: RampNetwork/kanar@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # this is passed automatically https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+          jira_token: ${{ secrets.JIRA_TOKEN }}
+          jira_token_user: ${{ secrets.JIRA_TOKEN_USER }}


### PR DESCRIPTION
## Motivation

This change is driven by the company-wide migration from ClickUp to Jira and renaming CliCop to Kanar.
Kanar integrates with Jira, while no longer supporting ClickUp, making introducing Kanar essential for completing the Jira migration.

## Intended outcome

Temporarily run Kanar alongside CliCop. We cannot replace CliCop with Kanar immediately, because Github required checks still require
CliCop workflow to run. Once we replace them to expect Kanar workflow instead, we will be free to remove CliCop from CI.

## Overview of changes

- add Github Actions workflow for [Kanar](https://github.com/RampNetwork/kanar)

## Quality assurance

If Kanar workflow is green for this PR and detects Jira issue from the title, then it is fine :)